### PR TITLE
New strategy for 50th and 95th percentiles

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -9,13 +9,13 @@ import numpy as np
 from tqdm import trange
 
 # Add your new class here
-from strategies.n_guess import NGuess
+from strategies.max_clue_entropy import MaxClueEntropy
 
 # Instantiate it at most 3 times with different parameters here
 STRATEGIES_UNDER_TEST = [
-    NGuess(epsilon=7.8, G=3), # Targets 5th percentile
-    NGuess(epsilon=24, G=3), # Targets 50th percentile
-    NGuess(epsilon=34, G=4), # Targets 95th percentile
+    MaxClueEntropy(n_guesses=2, epsilon_per_guess=7.5, monte_carlo=400),  # aim for 5th percentile
+    MaxClueEntropy(n_guesses=3, epsilon_per_guess=13., monte_carlo=200),  # aim for 50th percentile
+    MaxClueEntropy(n_guesses=3, epsilon_per_guess=32., monte_carlo=200),  # aim for 95th percentile
 ]
 
 NUM_TRIALS = 10001

--- a/strategies/max_clue_entropy.py
+++ b/strategies/max_clue_entropy.py
@@ -1,0 +1,152 @@
+# Maximizes the entropy of the conditional clue distribution, given the previous clues.
+# Equivalent to minimizing the conditional entropy of the solution given observations.
+
+import itertools as it
+import os
+from typing import Optional
+
+import numpy as np
+from tqdm import tqdm
+
+from strategies.utils import valid, answers, is_consistent
+
+
+GUESS_LIST = sorted(valid)
+SOLUTION_LIST = sorted(answers)
+N_CLUES = 3**5
+
+
+class MaxClueEntropy:
+    def __init__(self, n_guesses: int, epsilon_per_guess: float, monte_carlo: Optional[int] = None):
+        # Params
+        self.total_guesses = n_guesses
+        self.epsilon_per_guess = epsilon_per_guess
+        self.monte_carlo = monte_carlo
+        
+        # Constants
+        self.clue_matrix = precompute_clue_matrix(cache='cache/clue_matrix.npy')
+        self.dist_matrix = precompute_distance_matrix()
+        self.all_clue_vecs = np.zeros((N_CLUES, 5), dtype=np.uint8)
+        for i in range(N_CLUES):
+            self.all_clue_vecs[i] = clue_to_vec(i)
+
+        # Variables
+        self.remaining_guesses = n_guesses
+        self.prob_s = np.zeros(len(SOLUTION_LIST), dtype=np.float64)
+        self.prob_s[:] = 1. / len(SOLUTION_LIST)
+
+    def first_move(self) -> tuple[str, float]:
+        self.prob_s[:] = 1. / len(SOLUTION_LIST)
+        self.remaining_guesses = self.total_guesses
+        return self._regular_move()
+
+    def next_move(self, guess, epsilon, clues):
+        self._update_p_s(guess, clues, epsilon)
+        self.remaining_guesses -= 1
+        if self.remaining_guesses == 0:
+            argmax = np.argmax(self.prob_s)
+            return SOLUTION_LIST[argmax], 0
+        return self._regular_move()
+    
+    def _regular_move(self) -> tuple[str, float]:
+        clue_probs = np.zeros((len(GUESS_LIST), N_CLUES), dtype=np.float64)
+        clue_probs[:] = 1e-10
+        for i, _ in enumerate(GUESS_LIST):
+            if self.monte_carlo:
+                js = np.random.choice(len(SOLUTION_LIST), size=self.monte_carlo, p=self.prob_s)
+                weights = 1. / (self.monte_carlo * self.prob_s)
+            else:
+                js = np.arange(len(SOLUTION_LIST))
+                weights = np.ones(len(SOLUTION_LIST), dtype=np.float64)
+            for j in js:
+                clue = self.clue_matrix[i, j]
+                n_flipss = self.dist_matrix[clue, :]
+                flip_probs = flip_prob(n_flipss, epsilon=self.epsilon_per_guess)
+                clue_probs[i] += self.prob_s[j] * flip_probs * weights[j]
+        entropies = -np.sum(clue_probs * np.log(clue_probs), axis=1)
+        argmax = np.argmax(entropies)
+        guess = GUESS_LIST[argmax]
+        return guess, self.epsilon_per_guess
+    
+    def _update_p_s(self, guess: str, clue: str, epsilon: float):
+        """Update the solution distribution given the guess and clue."""
+        for i, solution in enumerate(SOLUTION_LIST):
+            for j, (c, letter) in enumerate(zip(clue, guess)):
+                if is_consistent(solution, j, letter, c):
+                    self.prob_s[i] *= np.exp(epsilon / 5.)
+        self.prob_s /= np.sum(self.prob_s)
+    
+    def __str__(self):
+        return f"MaxClueEntropy(n_guesses={self.total_guesses}, epsilon_per_guess={self.epsilon_per_guess}, monte_carlo={self.monte_carlo})"
+
+
+def precompute_clue_matrix(cache: Optional[str] = None):
+    if cache and os.path.exists(cache):
+        print(f"Loading cached clue matrix: {cache}")
+        clue_matrix = np.load(cache)
+        if clue_matrix.shape != (len(GUESS_LIST), len(SOLUTION_LIST)):
+            raise ValueError(f"Cache file {cache} has wrong shape: {clue_matrix.shape}")
+        return clue_matrix
+    
+    print("Precomputing clue matrix...")
+    clue_matrix = np.zeros((len(GUESS_LIST), len(SOLUTION_LIST)), dtype=np.uint8)
+    iterator = it.product(enumerate(GUESS_LIST), enumerate(SOLUTION_LIST))
+    for (i, g), (j, s) in tqdm(iterator, total=clue_matrix.size):
+        clue_matrix[i, j] = make_response_code(g, s)
+    if cache:
+        os.makedirs(os.path.dirname(cache), exist_ok=True)
+        print(f"Saving clue matrix to {cache}")
+        np.save(cache, clue_matrix)
+
+    return clue_matrix
+
+
+def precompute_distance_matrix() -> np.ndarray:
+    """Precompute the number of flips required between all pairs of clues."""
+    print("Precomputing distance matrix...")
+    dist_matrix = np.zeros((N_CLUES, N_CLUES), dtype=np.uint8)
+    vecs = np.zeros((N_CLUES, 5), dtype=np.uint8)
+    for i in range(N_CLUES):
+        vecs[i] = clue_to_vec(i)
+    for i, j in it.product(range(N_CLUES), repeat=2):
+        dist_matrix[i, j] = np.sum(vecs[i] != vecs[j])
+    return dist_matrix
+
+
+def flip_prob(n_flips: int, epsilon: float) -> float:
+    """The probability of flipping n clues for a given epsilon."""
+    p_flip = 2./ (2. + np.exp(epsilon / 5.))
+    p_no_flip = 1. - p_flip
+    return p_flip**n_flips * p_no_flip**(5. - n_flips)
+
+
+def make_response_code(guess: str, solution: str) -> np.uint8:
+    """Convert a clue to an unsigned 8-bit integer.
+    The clue is the response to a guess for a given solution.
+    Each color in the clue is represented by a digit:
+    - 0: black
+    - 1: yellow
+    - 2: green
+
+    The 8-bit integer is then obtained by converting the clue to the five corresponding numbers
+    and interpreting them as a base-3 number in Little Endian order.
+
+    For example, the clue "🟩⬛🟨⬛⬛" would be represented as 00102 in base-3, which is
+    2 * 3^0 + 0 * 3^1 + 1 * 3^2 + 0 * 3^3 + 0 * 3^4 = 2 + 0 + 9 + 0 + 0 = 11 in decimal.
+    """
+    preds = np.zeros(5, dtype=np.uint8)
+    for idx, (guess_letter, solution_letter) in enumerate(zip(guess, solution)):
+        if guess_letter == solution_letter:
+            pred = 2
+        elif guess_letter in solution:
+            pred = 1
+        else:
+            pred = 0
+        preds[idx] = pred
+    # convert base-3 representation to int
+    return np.sum(preds * 3**np.arange(5), dtype=np.uint8)
+
+
+def clue_to_vec(clue: np.uint8) -> np.ndarray:
+    """Convert a clue number to a 5d vector of 0s, 1s, and 2s."""
+    return (clue // 3**np.arange(5)) % 3  # convert int to base-3 representation

--- a/strategies/max_clue_entropy.py
+++ b/strategies/max_clue_entropy.py
@@ -78,11 +78,10 @@ class MaxClueEntropy:
             else:
                 js = np.arange(len(SOLUTION_LIST))
                 weights = np.ones(len(SOLUTION_LIST), dtype=np.float64)
-            for j in js:
-                clue = self.clue_matrix[i, j]
-                n_flipss = self.dist_matrix[clue, :]
-                flip_probs = flip_prob(n_flipss, epsilon=self.epsilon_per_guess)
-                clue_probs[i] += self.prob_s[j] * flip_probs * weights[j]
+            clues = self.clue_matrix[i, js]
+            n_flipss = self.dist_matrix[clues, :]
+            flip_probs = flip_prob(n_flipss, epsilon=self.epsilon_per_guess)
+            clue_probs[i, :] += np.sum(self.prob_s[js, np.newaxis] * flip_probs * weights[js, np.newaxis], axis=0)
         entropies = -np.sum(clue_probs * np.log(clue_probs), axis=1)
         argmax = np.nanargmax(entropies)
         guess = GUESS_LIST[argmax]

--- a/strategies/utils.py
+++ b/strategies/utils.py
@@ -24,12 +24,14 @@ def update_prior(prior, guess, epsilon, clues):
 
 # Check whether a given clue is consistent with a word.
 def is_consistent(word, index, letter, clue):
-    if clue == ' ':
+    if clue == '.':
         return letter not in word
     if clue == 'i':
         return letter in word and word[index] != letter
     if clue == 'c':
         return word[index] == letter
+    else:
+        raise ValueError(f"Invalid clue '{clue}' for letter '{letter}' at index {index} in word '{word}'")
 
 # Updates the weight associated with a word based on a clue
 def update_weight(row, index, letter, clue, epsilon):


### PR DESCRIPTION
Hi Damien! Your blog post motivated me to implement a randomized version of [a strategy I had lying around](https://github.com/DarthPumpkin/wordle-ai) for regular wordle. It's based on minimizing the conditional entropy in $P(Solution \mid Clues)$. In my experiments, it seems to beat the `NGuess` strategy on the 50th and 95th percentiles, so I figured why not submit it to the competition 🙂 See plots below.


Some comments:
- On my laptop, the strategy takes ca. 4 seconds to run, which is just below the 5-second timeout specified in `evaluate.py`, but it may or may not time out on different hardware. If needed, I can add an adaptive timeout to the strategy to make sure it always finishes on time.
- I think there was a bug in `utils.py`, which I fixed. Let me know if that's a misunderstanding.
- It looks like `evaluate.py` is currently set to run 10 001 repetitions, which might be one zero too many? This would take ca. 33 hours to run...
- my implementation creates a `cache/` directory to store some precomputed matrices. Please let me know if that's a problem.

![plot.pdf](https://github.com/user-attachments/files/19924544/plot.pdf)
![plot.pdf](https://github.com/user-attachments/files/19924546/plot.pdf)